### PR TITLE
Add alpha-beta pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,42 +21,43 @@ This is definitely not rocket science being done here. Expect more minimax than 
 
 The following is an example of how it may unfold.
 
-We see the hero party, consisting of _Harubs_, as well as the enemy party, consisting of _Denah_ and _Peoul_. 
-_Denah_ deals only 5 damage with their stick, but _Peoul_ deals 20 with their fists, which will take
-_Harubs_ out in one hit. Regardless of _Peoul_ being the third one to move, the only viable option is
-for _Harubs_ to attack _Peoul_ first to ensure they can never make a move to begin with.
+We see the hero party, consisting of _Brull_, as well as the enemy party, consisting of _Ziuon_ and _Molphige_. 
+_Ziuon_ deals only 5 damage with their stick, but _Molphige_ deals 20 with their fists, which will take
+_Brull_ out in one hit. Regardless of _Molphige_ being the third one to move, the only viable option is
+for _Brull_ to attack _Molphige_ first to ensure they can never make a move to begin with.
 
 That is indeed what happens:
 
 ```
+Performed 705 evaluations with 167 cuts in 259.724µs
 TL;DR: The initiating party wins with a score of 10.
 
 On the attacking side:
-- Harubs, with 20 health and their fists (10 damage)
+- Brull, with 20 health and their fists (10 damage)
 
 On the defending side:
-- Denah, with 15 health and a stick (5 damage)
-- Peoul, with 10 health and their fists (20 damage)
+- Ziuon, with 15 health and a stick (5 damage)
+- Molphige, with 10 health and their fists (20 damage)
 
-Turn 1:
-  Harubs whacks Peoul with their fists, dealing 10 damage
-   ⇒ Peoul has given up on being alive
+Turn 1 (discovered at step 1):
+  Brull whacks Molphige with their fists, dealing 10 damage
+   ⇒ Molphige has given up on being alive
 
-Turn 2:
-  Denah whacks Harubs with a stick, dealing 5 damage
-   ⇒ Harubs now has 15 health
+Turn 2 (discovered at step 2):
+  Ziuon whacks Brull with a stick, dealing 5 damage
+   ⇒ Brull now has 15 health
 
-Turn 3:
-  Harubs whacks Denah with their fists, dealing 10 damage
-   ⇒ Denah now has 5 health
+Turn 3 (discovered at step 3):
+  Brull whacks Ziuon with their fists, dealing 10 damage
+   ⇒ Ziuon now has 5 health
 
-Turn 4:
-  Denah whacks Harubs with a stick, dealing 5 damage
-   ⇒ Harubs now has 10 health
+Turn 4 (discovered at step 4):
+  Ziuon whacks Brull with a stick, dealing 5 damage
+   ⇒ Brull now has 10 health
 
-Turn 5:
-  Harubs whacks Denah with their fists, dealing 10 damage
-   ⇒ Denah has given up on being alive
+Turn 5 (discovered at step 5):
+  Brull whacks Ziuon with their fists, dealing 10 damage
+   ⇒ Ziuon has given up on being alive
 ```
 
 ## Rules of ~~Engagement~~ the Game

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This is definitely not rocket science being done here. Expect more minimax than 
 
 - [x] Regular minimax.
 - [x] Minimax with multiple turns per party.
+- [x] Implement Alpha-Beta pruning.
 - [ ] Implement Iterative Deepening.
-- [ ] Implement Alpha-Beta pruning.
 
 ## Example outcome
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,6 @@
 use crate::party::Participant;
 use crate::weapon::Weapon;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 /// An applied action.
 #[derive(Debug, Clone, PartialEq)]
@@ -42,6 +42,16 @@ impl Debug for SimpleAttackAction {
         match self.weapon {
             None => write!(f, "fists"),
             Some(ref weapon) => write!(f, "{:?}", weapon),
+        }
+    }
+}
+
+impl Display for AppliedAction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.action {
+            Action::SimpleAttack(_) => {
+                write!(f, "{} attacks {}", self.source, self.target)
+            }
         }
     }
 }

--- a/src/action_iterator.rs
+++ b/src/action_iterator.rs
@@ -72,6 +72,12 @@ impl Iterator for ActionIterator {
                 return None;
             }
 
+            // Ensure the current member can act
+            if !self.current.members[self.current_index].can_act() {
+                self.current_index += 1;
+                continue;
+            }
+
             if self.iter.is_none() {
                 let member = self.current.members[self.current_index].clone();
                 let target_range = 0..self.opponent.members.len();
@@ -89,7 +95,6 @@ impl Iterator for ActionIterator {
 
                     // TODO: Rework action generation - should only generate applicable actions to begin with.
                     if !opponent.is_applicable(&action) {
-                        self.current_index += 1;
                         continue;
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod conflict;
 mod party;
 mod party_member;
 mod solver;
+mod value;
 mod weapon;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,8 @@ fn main() {
     let outcome = Solver::engage(&conflict, 200);
 
     println!(
-        "Performed {} evaluations with {} cuts",
-        outcome.evaluations, outcome.cuts
+        "Performed {} evaluations with {} cuts in {:?}",
+        outcome.evaluations, outcome.cuts, outcome.search_duration
     );
     match outcome.outcome {
         OutcomeType::Win(score) => println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,10 @@ fn main() {
 
     let outcome = Solver::engage(&conflict, 200);
 
+    println!(
+        "Performed {} evaluations with {} cuts",
+        outcome.evaluations, outcome.cuts
+    );
     match outcome.outcome {
         OutcomeType::Win(score) => println!(
             "{} {} with a score of {}.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
         opponent: villains,
     };
 
-    let outcome = Solver::engage(&conflict);
+    let outcome = Solver::engage(&conflict, 200);
 
     match outcome.outcome {
         OutcomeType::Win(score) => println!(
@@ -76,10 +76,11 @@ fn main() {
             "The initiating party is defeated".red(),
             score
         ),
-        OutcomeType::Unknown => println!(
-            "{} {}.",
+        OutcomeType::Unknown(score) => println!(
+            "{} {}, the best hypothesis is a score of {}.",
             "TL;DR:".bright_white(),
-            "Anything could happen".white()
+            "Anything could happen".white(),
+            score
         ),
     }
 

--- a/src/party.rs
+++ b/src/party.rs
@@ -1,4 +1,5 @@
 use crate::party_member::PartyMember;
+use std::fmt::{Display, Formatter};
 
 /// A party, or faction in a conflict.
 #[derive(Debug, Clone)]
@@ -42,5 +43,11 @@ impl Party {
     /// Returns the size of the party.
     pub fn len(&self) -> usize {
         self.members.len()
+    }
+}
+
+impl Display for Participant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.party_id, self.member_id)
     }
 }

--- a/src/party_member.rs
+++ b/src/party_member.rs
@@ -103,6 +103,15 @@ impl Iterator for AttackIterator {
                 self.index += 1;
                 Some(action)
             }
+            1 => {
+                let action = Action::SimpleAttack(SimpleAttackAction {
+                    weapon: None,
+                    damage: 1.0,
+                });
+
+                self.index += 1;
+                Some(action)
+            }
             _ => None,
         }
     }

--- a/src/party_member.rs
+++ b/src/party_member.rs
@@ -61,6 +61,11 @@ impl PartyMember {
         AttackIterator::new(self)
     }
 
+    /// Determines whether the current member can act..
+    pub fn can_act(&self) -> bool {
+        !self.is_dead()
+    }
+
     /// Determines whether the action is applicable to this member.
     pub fn is_applicable(&self, _action: &Action) -> bool {
         !self.is_dead()

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -5,6 +5,7 @@ use crate::party::Participant;
 use crate::value::{Cutoff, TerminalState, Value};
 use log::trace;
 use std::fmt::{Display, Formatter};
+use std::time::{Duration, Instant};
 
 pub struct Solver;
 
@@ -39,6 +40,7 @@ impl Solver {
         // Some statistics.
         let mut evaluations = 0;
         let mut pruning_cuts = 0;
+        let start_time = Instant::now();
 
         let mut dfs_queue = Vec::from([0]);
         'dfs: while let Some(id) = dfs_queue.pop() {
@@ -149,7 +151,8 @@ impl Solver {
             nodes[node_id] = node;
         }
 
-        Self::backtrack(nodes, evaluations, pruning_cuts)
+        let search_duration = Instant::now() - start_time;
+        Self::backtrack(nodes, evaluations, pruning_cuts, search_duration)
     }
 
     /// Implements the minimax recursion as an expansion of the search tree.
@@ -270,7 +273,12 @@ impl Solver {
     }
 
     /// Backtracks the events from the start to one of the the most likely outcomes.
-    fn backtrack(nodes: Vec<Node>, evaluations: usize, pruning_cuts: usize) -> Outcome {
+    fn backtrack(
+        nodes: Vec<Node>,
+        evaluations: usize,
+        pruning_cuts: usize,
+        search_duration: Duration,
+    ) -> Outcome {
         // The outcome is positive only if the value of the start
         // node is positive and under the assumption that the opposing
         // player attempts to play optimally.
@@ -306,6 +314,7 @@ impl Solver {
             timeline: stack,
             evaluations,
             cuts: pruning_cuts,
+            search_duration,
         }
     }
 
@@ -403,6 +412,8 @@ pub struct Outcome {
     pub evaluations: usize,
     /// The number of pruning steps performed.
     pub cuts: usize,
+    /// The search duration.
+    pub search_duration: Duration,
 }
 
 /// The type of outcome.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -41,7 +41,7 @@ impl Solver {
             // The clone here is a hack to get around borrowing rules.
             let mut node = nodes[id].clone();
             trace!(
-                "Exploring node {node} at depth {depth}; {direction} within brackets α={alpha}, β={beta}, best={value} at={best_child:?}",
+                "Exploring node {node} at depth {depth}; {direction} within α={alpha} β={beta}, best={value} at={best_child:?}",
                 depth = node.depth,
                 direction = if node.is_maximizing { "maximizing"} else {"minimizing"},
                 alpha = node.value.alpha,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -2,8 +2,9 @@ use crate::action::AppliedAction;
 use crate::action_iterator::ActionIterator;
 use crate::conflict::Conflict;
 use crate::party::Participant;
-use crate::value::Value;
+use crate::value::{Cutoff, TerminalState, Value};
 use log::trace;
+use std::fmt::{Display, Formatter};
 
 pub struct Solver;
 
@@ -13,11 +14,12 @@ impl Solver {
     ///
     /// ## Arguments
     /// * `conflict` - The conflict situation to resolve.
+    /// * `max_depth` - The maximum search depth.
     ///
     /// ## Returns
     /// The [`Outcome`] of the conflict.
-    pub fn engage(conflict: &Conflict) -> Outcome {
-        let max_depth = 200; // TODO: arbitrarily chosen number
+    pub fn engage(conflict: &Conflict, max_depth: usize) -> Outcome {
+        let max_depth = max_depth.max(1);
         Self::minimax(conflict, max_depth)
     }
 
@@ -32,56 +34,113 @@ impl Solver {
     fn minimax(conflict: &Conflict, max_depth: usize) -> Outcome {
         // We start with a maximizing step, so the value is
         // initialized to negative infinity.
-        let mut nodes = vec![Node::new_root(conflict.clone(), max_depth)];
+        let mut nodes = vec![Node::new_root(conflict.clone(), 0)];
 
         let mut dfs_queue = Vec::from([0]);
         'dfs: while let Some(id) = dfs_queue.pop() {
             // The clone here is a hack to get around borrowing rules.
             let mut node = nodes[id].clone();
             trace!(
-                "Exploring node {node} at depth {depth}; maximizing: {is_maximizing}",
-                node = id,
+                "Exploring node {node} at depth {depth}; {direction} within brackets α={alpha}, β={beta}, best={value} at={best_child:?}",
                 depth = node.depth,
-                is_maximizing = node.is_maximizing
+                direction = if node.is_maximizing { "maximizing"} else {"minimizing"},
+                alpha = node.value.alpha,
+                beta = node.value.beta,
+                value = node.value.value,
+                best_child = node.best_child
             );
 
-            // If this is a terminal node we either have a winner or loser.
-            // TODO: We may decide to stop searching if the initiating party wins or decide to find the best possible outcome.
-            //       Since all of minimax assumes both players play optimally, selecting the optimal win (i.e. the highest
-            //       possible value) may give more tolerance for erratic behavior of the opponent.
-            if let Some(value) = Self::get_utility(&node.state) {
-                trace!("Node {node} is a terminal, found value {value}", node = id);
-
-                // Update the value in the nodes set first before iterating.
-                node.value = node.value.with_value(value);
-                node.best_child = Some(id);
-                nodes[id].value = node.value.clone();
-                nodes[id].best_child = Some(id);
-                Self::propagate_values(&mut nodes, &mut node);
+            // Terminate iteration if the look-ahead depth is reached.
+            if node.depth == max_depth {
+                *node.value = Self::get_utility(&node.state);
+                nodes[node.id].value = node.value.clone();
+                trace!(
+                    "Search depth reached, terminating search on node {node} with {value}",
+                    value = *node.value
+                );
+                Self::propagate_to_parent(&mut nodes, &mut node);
                 continue 'dfs;
             }
 
-            // Also terminate iteration if the look-ahead depth is reached.
-            if node.depth == 0 {
+            // Test for alpha or beta cutoffs.
+            if node.is_maximizing && node.value.is_beta_cutoff() {
                 trace!(
-                    "Search depth reached, terminating search on node {node}",
-                    node = id
+                    "Beta cutoff at value={value} >= β={beta} - stopping expansion",
+                    value = node.value.value,
+                    beta = node.value.beta
                 );
-                node.best_child = Some(id);
-                nodes[id].best_child = Some(id);
-                Self::propagate_values(&mut nodes, &mut node);
+
+                Self::propagate_to_parent(&mut nodes, &mut node);
+                continue 'dfs;
+            } else if !node.is_maximizing && node.value.is_alpha_cutoff() {
+                trace!(
+                    "Alpha cutoff at value={value} <= α={alpha} - stopping expansion",
+                    value = node.value.value,
+                    alpha = node.value.alpha
+                );
+
+                Self::propagate_to_parent(&mut nodes, &mut node);
+                continue 'dfs;
+            } else if !node.is_maximizing && node.value.is_negative() {
+                trace!(
+                    "Minimizer found defeat with value={value} - stopping expansion",
+                    value = node.value.value
+                );
+
+                Self::propagate_to_parent(&mut nodes, &mut node);
                 continue 'dfs;
             }
 
             // Expand the search tree at the current node.
-            let node = Self::minimax_expand(node, &mut nodes, &mut dfs_queue);
+            let node = match Self::minimax_expand(node, &mut nodes, &mut dfs_queue) {
+                ExpansionResult::Expanded(node) => node,
+                ExpansionResult::Exhausted(mut node) => {
+                    let value = if (*node.value).is_finite() {
+                        trace!(
+                            "Node {node} (child of {parent_node}) fully explored, got value {value}",
+                            value = *node.value,
+                            parent_node = nodes[node.parent_id.unwrap_or(0)]
+                        );
+                        *node.value
+                    } else {
+                        // If this is a terminal node we either have a winner or loser.
+                        let value = Self::get_utility(&node.state);
+                        match value {
+                            TerminalState::Win(value) =>
+                                trace!(
+                                    "Node {node} (child of {parent_node}) is a terminal, got value {value} (win)",
+                                    parent_node = nodes[node.parent_id.unwrap_or(0)]
+                                ),
+                            TerminalState::Defeat(value) =>
+                                trace!(
+                                    "Node {node} (child of {parent_node}) is a terminal, got value {value} (defeat)",
+                                    parent_node = nodes[node.parent_id.unwrap_or(0)]
+                                ),
+                            TerminalState::Heuristic(value) =>
+                                trace!(
+                                    "Node {node} (child of {parent_node}) exhausted, got value {value} (heuristic)",
+                                    parent_node = nodes[node.parent_id.unwrap_or(0)]
+                                )
+                        }
+                        value
+                    };
+
+                    // Update the value in the nodes set first before iterating.
+                    node.value.value = value;
+                    nodes[id].value = node.value.clone();
+
+                    // Update the value in the nodes set first before iterating.
+                    Self::propagate_to_parent(&mut nodes, &mut node);
+                    node
+                }
+            };
 
             // Replace the node in the original array with our clone.
             let node_id = node.id;
             nodes[node_id] = node;
         }
 
-        Self::backtrack(nodes, max_depth)
+        Self::backtrack(nodes)
     }
 
     /// Implements the minimax recursion as an expansion of the search tree.
@@ -93,7 +152,11 @@ impl Solver {
     ///
     /// ## Returns
     /// The same node that was passed in.
-    fn minimax_expand(mut node: Node, nodes: &mut Vec<Node>, frontier: &mut Vec<usize>) -> Node {
+    fn minimax_expand(
+        mut node: Node,
+        nodes: &mut Vec<Node>,
+        frontier: &mut Vec<usize>,
+    ) -> ExpansionResult {
         // Select the currently active party.
         let current = if node.is_maximizing {
             &node.state.initiator
@@ -171,11 +234,15 @@ impl Solver {
                     node.id,
                     &node.value,
                     !node.is_maximizing,
-                    node.depth - 1,
+                    node.depth + 1,
                     node.turn + 1,
                     state,
                     action,
                 );
+
+                if let Some(action) = &node.action {
+                    trace!("Expand node {node} into {child_node} with action: {action}");
+                }
 
                 // Since the actions were not exhausted yet, we push the parent node again.
                 frontier.push(node.id);
@@ -184,24 +251,25 @@ impl Solver {
                 // Now push the child node so that we can explore it.
                 frontier.push(child_node.id);
                 nodes.push(child_node);
+
+                // TODO: Return the child node, let the caller mutate the search frontier.
+                return ExpansionResult::Expanded(node);
             }
         }
 
-        node
+        ExpansionResult::Exhausted(node)
     }
 
     /// Backtracks the events from the start to one of the the most likely outcomes.
-    fn backtrack(nodes: Vec<Node>, max_depth: usize) -> Outcome {
+    fn backtrack(nodes: Vec<Node>) -> Outcome {
         // The outcome is positive only if the value of the start
         // node is positive and under the assumption that the opposing
         // player attempts to play optimally.
         let value = nodes[0].value.value;
-        let outcome = if value.is_infinite() {
-            OutcomeType::Unknown
-        } else if value >= 0.0 {
-            OutcomeType::Win(value)
-        } else {
-            OutcomeType::Lose(value)
+        let outcome = match value {
+            TerminalState::Win(score) => OutcomeType::Win(score),
+            TerminalState::Defeat(score) => OutcomeType::Lose(score),
+            TerminalState::Heuristic(score) => OutcomeType::Unknown(score),
         };
 
         let mut stack = Vec::default();
@@ -213,16 +281,11 @@ impl Solver {
                 is_initiator_turn: node.is_maximizing,
                 action: node.action.clone().expect(""),
                 state: node.state.clone(),
-                depth: max_depth - node.depth,
+                depth: node.depth,
             });
 
-            if let Some(parent_id) = node.parent_id {
-                // The root node has no action, so stop here.
-                if parent_id == 0 {
-                    break;
-                }
-
-                node = &nodes[parent_id];
+            if let Some(best_child) = node.best_child {
+                node = &nodes[best_child];
                 continue 'backtracking;
             }
 
@@ -231,62 +294,56 @@ impl Solver {
 
         Outcome {
             outcome,
-            timeline: stack.into_iter().rev().collect(),
+            timeline: stack,
         }
     }
 
     /// Propagates known terminal utility values upwards in the
     /// search tree.
-    fn propagate_values(nodes: &mut Vec<Node>, node: &Node) {
-        let mut parent_id = node.parent_id;
-        let mut child_id = node.id;
-        let mut outcome_changed = true;
+    fn propagate_to_parent(nodes: &mut Vec<Node>, child_node: &Node) -> Cutoff {
+        let parent_id = child_node.parent_id;
 
-        debug_assert_ne!(node.best_child, None, "No best child set");
-
-        while let Some(id) = parent_id {
+        if let Some(id) = parent_id {
             // Note that the child value is only finite if we reached
             // a terminal state and will be ±infinite if the search
             // terminated due to search depth limitation.
-            let child_value = nodes[child_id].value.clone();
-            let best_child = nodes[child_id].best_child;
+            let child_value = child_node.value.clone();
 
-            let node = &mut nodes[id];
-            let old_value = node.value.clone();
+            let parent_node = &mut nodes[id];
+            if parent_node.is_maximizing {
+                if child_value.value > *parent_node.value {
+                    *parent_node.value = child_value.value;
+                    parent_node.best_child = Some(child_node.id);
+                }
 
-            if node.is_maximizing {
-                node.value = node.value.max(child_value.clone());
+                if parent_node.value.is_beta_cutoff() {
+                    // beta-cutoff
+                    return Cutoff::Beta;
+                } else {
+                    parent_node.value.alpha =
+                        parent_node.value.alpha.max(child_value.value.value());
+                }
             } else {
-                node.value = node.value.min(child_value.clone());
+                if child_value.value < *parent_node.value {
+                    *parent_node.value = child_value.value;
+                    parent_node.best_child = Some(child_node.id);
+                }
+
+                if parent_node.value.is_alpha_cutoff() {
+                    // alpha-cutoff
+                    return Cutoff::Alpha;
+                } else {
+                    parent_node.value.beta = parent_node.value.beta.min(child_value.value.value());
+                }
             }
-
-            // TODO: Propagate alpha/beta brackets to "right" child nodes of the parent
-
-            // TODO: terminate propagation if value did not change.
-            if !outcome_changed {
-                // Here only for sanity checking. We'd like to terminate
-                // the upwards propagation instead.
-                debug_assert_eq!(
-                    node.value, old_value,
-                    "If the value started being unchanged, no new changes are introduced upstream."
-                );
-            } else if child_value.is_finite() && node.value == old_value {
-                outcome_changed = false;
-            }
-
-            if outcome_changed || node.best_child.is_none() {
-                node.best_child = best_child;
-                debug_assert_ne!(node.best_child, None, "No best child detected");
-            }
-
-            parent_id = node.parent_id;
-            child_id = id;
         }
+
+        Cutoff::None
     }
 
     /// Gets the utility of the current node. Will return `None` if this
     /// is not a terminal state, i.e. no party has won or lost.
-    fn get_utility(state: &Conflict) -> Option<f32> {
+    fn get_utility(state: &Conflict) -> TerminalState {
         if state.initiator.is_defeated() {
             // The current party being dead is a terminal state and always is a negative reward.
             // We sum up the total damage taken to punish strong defeats
@@ -298,27 +355,29 @@ impl Solver {
                 .map(|m| -m.damage_taken)
                 .sum();
             debug_assert!(utility < 0.0);
-            Some(utility)
-        } else if state.opponent.is_defeated() {
-            // As a naive choice, we simply sum up the health of each member.
-            // This is to ensure we play less risky and don't need to heal as much.
-            // Health can never be negative, but to be sure we cap it at zero.
-            //
-            // In theory we can also factor in the damage taken by the opponent
-            // as dealing more damage could be useful. Whether or not that is a
-            // useful idea depends on the remaining game mechanics (say, e.g., a massive
-            // magical effect that takes a day to recover vs. death by a slap with a stick).
-            let utility = state
-                .initiator
-                .members
-                .iter()
-                .map(|m| m.health.max(0.0))
-                .sum();
-            debug_assert!(utility > 0.0);
-            Some(utility)
+            return TerminalState::Defeat(utility);
+        }
+
+        // As a naive choice, we simply sum up the health of each member.
+        // This is to ensure we play less risky and don't need to heal as much.
+        // Health can never be negative, but to be sure we cap it at zero.
+        //
+        // In theory we can also factor in the damage taken by the opponent
+        // as dealing more damage could be useful. Whether or not that is a
+        // useful idea depends on the remaining game mechanics (say, e.g., a massive
+        // magical effect that takes a day to recover vs. death by a slap with a stick).
+        let utility = state
+            .initiator
+            .members
+            .iter()
+            .map(|m| m.health.max(0.0))
+            .sum();
+        debug_assert!(utility > 0.0);
+
+        if state.opponent.is_defeated() {
+            TerminalState::Win(utility)
         } else {
-            // Neither party has lost, so this is not a terminal state.
-            None
+            TerminalState::Heuristic(utility * 0.1)
         }
     }
 }
@@ -332,14 +391,14 @@ pub struct Outcome {
 }
 
 /// The type of outcome.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum OutcomeType {
     /// The initiating party wins.
     Win(f32),
     /// The initiating party loses.
     Lose(f32),
     /// Unknown outcome.
-    Unknown,
+    Unknown(f32),
 }
 
 /// An event in the timeline.
@@ -354,6 +413,14 @@ pub struct Event {
     pub depth: usize,
     /// The state of the conflict after the action took place.
     pub state: Conflict,
+}
+
+/// A tree expansion outcome.
+enum ExpansionResult {
+    /// A new node was added.
+    Expanded(Node),
+    /// No new node was added.
+    Exhausted(Node),
 }
 
 /// A node in the game tree.
@@ -398,7 +465,7 @@ impl Node {
             depth: max_depth,
             turn: 0,
             is_maximizing: true,
-            value: Value::new(f32::NEG_INFINITY),
+            value: Value::new(TerminalState::Heuristic(f32::NEG_INFINITY)),
             best_child: None,
             action: None,
             state: conflict,
@@ -424,9 +491,9 @@ impl Node {
             parent_id: Some(parent_id),
             is_maximizing,
             value: if is_maximizing {
-                parent_value.with_value(f32::NEG_INFINITY)
+                parent_value.with_value(TerminalState::Heuristic(f32::NEG_INFINITY))
             } else {
-                parent_value.with_value(f32::INFINITY)
+                parent_value.with_value(TerminalState::Heuristic(f32::INFINITY))
             },
             best_child: None,
             depth,
@@ -435,6 +502,16 @@ impl Node {
             action_iter: None,
             state,
             child_nodes: Vec::default(),
+        }
+    }
+}
+
+impl Display for Node {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_maximizing {
+            write!(f, "↑{}", self.id)
+        } else {
+            write!(f, "↓{}", self.id)
         }
     }
 }
@@ -474,7 +551,7 @@ mod tests {
             opponent: villains,
         };
 
-        let solution = Solver::engage(&conflict);
+        let solution = Solver::engage(&conflict, 200);
         assert_eq!(solution.outcome, OutcomeType::Win(5.0));
     }
 
@@ -514,7 +591,7 @@ mod tests {
             opponent: villains,
         };
 
-        let solution = Solver::engage(&conflict);
+        let solution = Solver::engage(&conflict, 100);
         assert_eq!(solution.outcome, OutcomeType::Win(10.0));
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,27 @@
-use std::fmt::{Debug, Formatter};
-use std::ops::Deref;
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::{Deref, DerefMut};
+
+/// Describes a cutoff event.
+pub enum Cutoff {
+    /// No value was cut off.
+    None,
+    /// An alpha cutoff was observed.
+    Alpha,
+    /// A beta cutoff was observed.
+    Beta,
+}
+
+/// A terminal state.
+#[derive(Debug, Copy, Clone)]
+pub enum TerminalState {
+    /// The maximizing player wins.
+    Win(f32),
+    /// The maximizing player loses.
+    Defeat(f32),
+    /// No clear decision can be made.
+    Heuristic(f32),
+}
 
 /// A value triplet in Alpha-Beta pruning.
 #[derive(Clone, PartialEq, PartialOrd)]
@@ -11,7 +33,7 @@ pub struct Value {
     /// the alpha value will be increased accordingly.
     pub alpha: f32,
     /// The current value.
-    pub value: f32,
+    pub value: TerminalState,
     /// The highest value that can be reached by the player.
     ///
     /// ## Minimax - Maximizing Player
@@ -26,61 +48,121 @@ pub struct Value {
 
 impl Value {
     /// Initializes a new value with default alpha and beta bounds.
-    pub const fn new(value: f32) -> Self {
+    pub const fn new(value: TerminalState) -> Self {
         Self::new_with(f32::NEG_INFINITY, value, f32::INFINITY)
     }
 
     /// Initializes a new value with provided alpha and beta bounds.
-    pub const fn new_with(alpha: f32, value: f32, beta: f32) -> Self {
+    pub const fn new_with(alpha: f32, value: TerminalState, beta: f32) -> Self {
         Self { alpha, value, beta }
     }
 
     /// Creates a new instance, overwriting the alpha value.
-    pub const fn with_alpha(&self, alpha: f32) -> Self {
-        Self::new_with(alpha, self.value, self.beta)
-    }
-
-    /// Creates a new instance, overwriting the alpha value.
-    pub const fn with_value(&self, value: f32) -> Self {
+    pub const fn with_value(&self, value: TerminalState) -> Self {
         Self::new_with(self.alpha, value, self.beta)
     }
 
-    /// Creates a new instance, overwriting the alpha value.
-    pub const fn with_beta(&self, beta: f32) -> Self {
-        Self::new_with(self.alpha, self.value, beta)
+    /// Tests whether the current score results in an alpha cutoff.
+    pub fn is_alpha_cutoff(&self) -> bool {
+        // TODO: We might remove the is_finite() check here.
+        self.value.is_finite() && self.value.value() <= self.alpha
     }
 
-    pub fn max(&self, other: Value) -> Value {
-        todo!("this is wrong");
-        let value = self.value.max(other.value);
-        Self {
-            alpha: self.alpha.max(value),
-            value,
-            beta: self.beta,
-        }
-    }
-
-    pub fn min(&self, other: Value) -> Value {
-        todo!("this is wrong");
-        let value = self.value.min(other.value);
-        Self {
-            alpha: self.alpha,
-            value,
-            beta: self.beta.min(value),
-        }
+    /// Tests whether the current score results in a beta cutoff.
+    pub fn is_beta_cutoff(&self) -> bool {
+        // TODO: We might remove the is_finite() check here.
+        self.value.is_finite() && self.value.value() >= self.beta
     }
 }
 
 impl Deref for Value {
-    type Target = f32;
+    type Target = TerminalState;
 
     fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
 
+impl DerefMut for Value {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
 impl Debug for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{}, {}, {}]", self.alpha, self.value, self.beta)
+    }
+}
+
+impl TerminalState {
+    pub const fn value(&self) -> f32 {
+        match self {
+            TerminalState::Win(value) => *value,
+            TerminalState::Defeat(value) => *value,
+            TerminalState::Heuristic(value) => *value,
+        }
+    }
+
+    pub fn is_negative(&self) -> bool {
+        self.value() < 0.0
+    }
+}
+
+impl Deref for TerminalState {
+    type Target = f32;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            TerminalState::Win(value) => value,
+            TerminalState::Defeat(value) => value,
+            TerminalState::Heuristic(value) => value,
+        }
+    }
+}
+
+impl Display for TerminalState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TerminalState::Win(value) => write!(f, "win({})", value),
+            TerminalState::Defeat(value) => write!(f, "defeat({})", value),
+            TerminalState::Heuristic(value) => write!(f, "H({})", value),
+        }
+    }
+}
+
+impl PartialEq for TerminalState {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().eq(&other.value())
+    }
+}
+
+impl PartialOrd for TerminalState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value().partial_cmp(&other.value())
+    }
+}
+
+impl PartialEq<f32> for TerminalState {
+    fn eq(&self, other: &f32) -> bool {
+        self.value().eq(other)
+    }
+}
+
+impl PartialOrd<f32> for TerminalState {
+    fn partial_cmp(&self, other: &f32) -> Option<Ordering> {
+        self.value().partial_cmp(other)
+    }
+}
+
+impl PartialEq<TerminalState> for f32 {
+    fn eq(&self, other: &TerminalState) -> bool {
+        self.eq(&other.value())
+    }
+}
+
+impl From<TerminalState> for f32 {
+    fn from(value: TerminalState) -> Self {
+        value.value()
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,86 @@
+use std::fmt::{Debug, Formatter};
+use std::ops::Deref;
+
+/// A value triplet in Alpha-Beta pruning.
+#[derive(Clone, PartialEq, PartialOrd)]
+pub struct Value {
+    /// The lowest value that can be reached by the player.
+    ///
+    /// ## Minimax - Maximizing Player
+    /// If a maximizing player observes a value higher than the alpha value,
+    /// the alpha value will be increased accordingly.
+    pub alpha: f32,
+    /// The current value.
+    pub value: f32,
+    /// The highest value that can be reached by the player.
+    ///
+    /// ## Minimax - Maximizing Player
+    /// If a maximizing player observes a score higher than the
+    /// beta value, the search can be terminated because the value
+    /// already exceeds the highest guarantee a minimizing player will make.
+    ///
+    /// In other words, while other branches may yield higher scores,
+    /// the minimizing player would never pick them.
+    pub beta: f32,
+}
+
+impl Value {
+    /// Initializes a new value with default alpha and beta bounds.
+    pub const fn new(value: f32) -> Self {
+        Self::new_with(f32::NEG_INFINITY, value, f32::INFINITY)
+    }
+
+    /// Initializes a new value with provided alpha and beta bounds.
+    pub const fn new_with(alpha: f32, value: f32, beta: f32) -> Self {
+        Self { alpha, value, beta }
+    }
+
+    /// Creates a new instance, overwriting the alpha value.
+    pub const fn with_alpha(&self, alpha: f32) -> Self {
+        Self::new_with(alpha, self.value, self.beta)
+    }
+
+    /// Creates a new instance, overwriting the alpha value.
+    pub const fn with_value(&self, value: f32) -> Self {
+        Self::new_with(self.alpha, value, self.beta)
+    }
+
+    /// Creates a new instance, overwriting the alpha value.
+    pub const fn with_beta(&self, beta: f32) -> Self {
+        Self::new_with(self.alpha, self.value, beta)
+    }
+
+    pub fn max(&self, other: Value) -> Value {
+        todo!("this is wrong");
+        let value = self.value.max(other.value);
+        Self {
+            alpha: self.alpha.max(value),
+            value,
+            beta: self.beta,
+        }
+    }
+
+    pub fn min(&self, other: Value) -> Value {
+        todo!("this is wrong");
+        let value = self.value.min(other.value);
+        Self {
+            alpha: self.alpha,
+            value,
+            beta: self.beta.min(value),
+        }
+    }
+}
+
+impl Deref for Value {
+    type Target = f32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl Debug for Value {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}, {}, {}]", self.alpha, self.value, self.beta)
+    }
+}


### PR DESCRIPTION
This now adds alpha-beta pruning with the extra addition that all branches found by a minimizer that evaluate to a negative score will be cut off as well since at that point it does not help optimizing the beta bound to an even lower value.