### PR TITLE
Add retreat gameplay mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ for _Brull_ to attack _Molphige_ first to ensure they can never make a move to b
 That is indeed what happens:
 
 ```
-Performed 705 evaluations with 167 cuts in 259.724µs
+Performed 921 evaluations with 221 cuts at depth 8 in 309.766µs. The encounter has 5 turns.
 TL;DR: The initiating party wins with a score of 10.
 
 On the attacking side:
@@ -58,6 +58,33 @@ Turn 4 (discovered at step 4):
 Turn 5 (discovered at step 5):
   Brull whacks Ziuon with their fists, dealing 10 damage
    ⇒ Ziuon has given up on being alive
+```
+
+If retreats are allowed for the enemy party, the game has a different outcome: The enemy
+now decides to flee at their first chance. The hero party still gets an extra move, but it is not
+enough to result in a defeat of the enemy.
+
+```
+Performed 1063 evaluations with 247 cuts at depth 8 in 360.599µs. The encounter has 3 turns.
+TL;DR: The initiating party let the opponent flee with a score of 2.
+
+On the attacking side:
+- Brull, with 20 health and their fists (10 damage)
+
+On the defending side:
+- Ziuon, with 15 health and a stick (5 damage)
+- Molphige, with 10 health and their fists (20 damage)
+
+Turn 1 (discovered at step 1):
+  Brull whacks Molphige with their fists, dealing 10 damage
+   ⇒ Molphige has given up on being alive
+
+Turn 2 (discovered at step 2):
+  the party flees
+
+Turn 3 (discovered at step 3):
+  Brull whacks Ziuon with their fists, dealing 10 damage
+   ⇒ Ziuon now has 5 health
 ```
 
 ## Rules of ~~Engagement~~ the Game

--- a/src/action.rs
+++ b/src/action.rs
@@ -2,9 +2,16 @@ use crate::party::Participant;
 use crate::weapon::Weapon;
 use std::fmt::{Debug, Display, Formatter};
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum AppliedAction {
+    Flee,
+    /// A party member targets another party member.
+    Targeted(TargetedAction),
+}
+
 /// An applied action.
 #[derive(Debug, Clone, PartialEq)]
-pub struct AppliedAction {
+pub struct TargetedAction {
     /// The action.
     pub action: Action,
     /// The source of the action.
@@ -48,10 +55,13 @@ impl Debug for SimpleAttackAction {
 
 impl Display for AppliedAction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.action {
-            Action::SimpleAttack(_) => {
-                write!(f, "{} attacks {}", self.source, self.target)
-            }
+        match self {
+            AppliedAction::Flee => write!(f, "the party retreats"),
+            AppliedAction::Targeted(action) => match action.action {
+                Action::SimpleAttack(_) => {
+                    write!(f, "{} attacks {}", action.source, action.target)
+                }
+            },
         }
     }
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AppliedAction {
+    /// The party retreats from the conflict.
     Flee,
     /// A party member targets another party member.
     Targeted(TargetedAction),

--- a/src/action_iterator.rs
+++ b/src/action_iterator.rs
@@ -20,6 +20,8 @@ pub struct ActionIterator {
     current_index: usize,
     /// The index range to address in the current party.
     current_range: Range<usize>,
+    /// Determines whether the retreat action was already emitted.
+    tried_retreat: bool,
     /// The iterator used to generated actions targeting an enemy party member..
     iter: Option<ActionTargetIterator>,
 }
@@ -58,6 +60,7 @@ impl ActionIterator {
             current_index: current_range.start,
             current_range,
             iter: None,
+            tried_retreat: false,
         }
     }
 }
@@ -69,6 +72,20 @@ impl Iterator for ActionIterator {
         loop {
             // If the end of the enumeration was reached, we can exit.
             if self.current_index >= self.current_range.end {
+                if !self.tried_retreat {
+                    self.tried_retreat = true;
+                    // TODO: Ensure that not every party can retreat.
+
+                    // No point in running away if the opponent is already running
+                    // or defeated. Likewise, ensure we can perform an action at all.
+                    if self.current.can_act()
+                        && !self.opponent.has_retreated()
+                        && !self.opponent.is_defeated()
+                    {
+                        return Some(AppliedAction::Flee);
+                    }
+                }
+
                 return None;
             }
 

--- a/src/action_iterator.rs
+++ b/src/action_iterator.rs
@@ -79,6 +79,7 @@ impl Iterator for ActionIterator {
                     // No point in running away if the opponent is already running
                     // or defeated. Likewise, ensure we can perform an action at all.
                     if self.current.can_act()
+                        && self.current.can_retreat()
                         && !self.opponent.has_retreated()
                         && !self.opponent.is_defeated()
                     {
@@ -195,6 +196,7 @@ mod tests {
                 health: 25.0,
                 damage_taken: 0.0,
                 weapon: Weapon::Stick(Stick { damage: 10.0 }),
+                can_act: true,
             },
             0..10,
         );
@@ -238,6 +240,7 @@ mod tests {
                 health: 25.0,
                 damage_taken: 0.0,
                 weapon: Weapon::Stick(Stick { damage: 10.0 }),
+                can_act: true,
             },
             10..20,
         );
@@ -281,14 +284,18 @@ mod tests {
                     health: 25.0,
                     damage_taken: 0.0,
                     weapon: Weapon::Stick(Stick { damage: 10.0 }),
+                    can_act: true,
                 },
                 PartyMember {
                     id: 1,
                     health: 25.0,
                     damage_taken: 0.0,
                     weapon: Weapon::Fists(Fists { damage: 5.0 }),
+                    can_act: true,
                 },
             ],
+            can_retreat: false,
+            retreated: false,
         };
 
         let villains = Party {
@@ -299,14 +306,18 @@ mod tests {
                     health: 25.0,
                     damage_taken: 0.0,
                     weapon: Weapon::Stick(Stick { damage: 10.0 }),
+                    can_act: true,
                 },
                 PartyMember {
                     id: 1,
                     health: 25.0,
                     damage_taken: 0.0,
                     weapon: Weapon::Stick(Stick { damage: 10.0 }),
+                    can_act: true,
                 },
             ],
+            can_retreat: false,
+            retreated: false,
         };
 
         let mut iter = ActionIterator::new(heroes, villains);
@@ -314,7 +325,7 @@ mod tests {
         // First player attacks first opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: Some(Weapon::Stick(Stick { damage: 10.0 })),
                     damage: 10.0
@@ -327,13 +338,13 @@ mod tests {
                     party_id: 1,
                     member_id: 0
                 }
-            })
+            }))
         );
 
         // First player attacks second opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: Some(Weapon::Stick(Stick { damage: 10.0 })),
                     damage: 10.0
@@ -346,13 +357,13 @@ mod tests {
                     party_id: 1,
                     member_id: 1
                 }
-            })
+            }))
         );
 
         // First player attacks first opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: None,
                     damage: 1.0
@@ -365,13 +376,13 @@ mod tests {
                     party_id: 1,
                     member_id: 0
                 }
-            })
+            }))
         );
 
         // First player attacks second opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: None,
                     damage: 1.0
@@ -384,13 +395,13 @@ mod tests {
                     party_id: 1,
                     member_id: 1
                 }
-            })
+            }))
         );
 
         // Second player attacks first opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: Some(Weapon::Fists(Fists { damage: 5.0 })),
                     damage: 5.0
@@ -403,13 +414,13 @@ mod tests {
                     party_id: 1,
                     member_id: 0
                 }
-            })
+            }))
         );
 
         // Second player attacks second opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: Some(Weapon::Fists(Fists { damage: 5.0 })),
                     damage: 5.0
@@ -422,13 +433,13 @@ mod tests {
                     party_id: 1,
                     member_id: 1
                 }
-            })
+            }))
         );
 
         // Second player attacks first opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: None,
                     damage: 1.0
@@ -441,13 +452,13 @@ mod tests {
                     party_id: 1,
                     member_id: 0
                 }
-            })
+            }))
         );
 
         // Second player attacks second opponent.
         assert_eq!(
             iter.next(),
-            Some(AppliedAction {
+            Some(AppliedAction::Targeted(TargetedAction {
                 action: Action::SimpleAttack(SimpleAttackAction {
                     weapon: None,
                     damage: 1.0
@@ -460,7 +471,7 @@ mod tests {
                     party_id: 1,
                     member_id: 1
                 }
-            })
+            }))
         );
 
         assert_eq!(iter.next(), None);

--- a/src/action_iterator.rs
+++ b/src/action_iterator.rs
@@ -1,4 +1,4 @@
-use crate::action::{Action, AppliedAction};
+use crate::action::{Action, AppliedAction, TargetedAction};
 use crate::party::{Participant, Party};
 use crate::party_member::{AttackIterator, PartyMember};
 use std::ops::Range;
@@ -108,11 +108,11 @@ impl Iterator for ActionIterator {
                         member_id: opponent.id,
                     };
 
-                    return Some(AppliedAction {
+                    return Some(AppliedAction::Targeted(TargetedAction {
                         action,
                         source,
                         target,
-                    });
+                    }));
                 }
             }
         }

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -4,9 +4,9 @@ use crate::party_member::PartyMember;
 /// A conflict, specifically the state of conflict at a given turn.
 #[derive(Debug, Clone)]
 pub struct Conflict {
-    /// The party initiating the conflict.
+    /// The party initiating the conflict, the maximizing player.
     pub initiator: Party,
-    /// The other involved party.
+    /// The other involved party, the minimizing player.
     pub opponent: Party,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,8 +70,12 @@ fn main() {
     let outcome = Solver::engage(&conflict, 10);
 
     println!(
-        "Performed {} evaluations with {} cuts at depth {} in {:?}",
-        outcome.evaluations, outcome.cuts, outcome.max_visited_depth, outcome.search_duration
+        "Performed {} evaluations with {} cuts at depth {} in {:?}. The encounter has {} turns.",
+        outcome.evaluations,
+        outcome.cuts,
+        outcome.max_visited_depth,
+        outcome.search_duration,
+        outcome.len()
     );
     match outcome.outcome {
         OutcomeType::Win(score) => println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::action::Action;
+use crate::action::{Action, AppliedAction};
 use crate::conflict::Conflict;
 use crate::party::{Participant, Party};
 use crate::party_member::PartyMember;
@@ -117,31 +117,36 @@ fn main() {
             event.depth
         );
 
-        match event.action.action {
-            Action::SimpleAttack(attack) => {
-                println!(
-                    "  {} whacks {} with {}, dealing {} damage",
-                    color_participant(initiator_party, &names, &event.action.source),
-                    color_participant(initiator_party, &names, &event.action.target),
-                    format!("{:?}", attack).yellow(),
-                    attack.damage
-                );
-            }
-        }
+        match event.action {
+            AppliedAction::Flee => println!("  the party flees"),
+            AppliedAction::Targeted(action) => {
+                match action.action {
+                    Action::SimpleAttack(attack) => {
+                        println!(
+                            "  {} whacks {} with {}, dealing {} damage",
+                            color_participant(initiator_party, &names, &action.source),
+                            color_participant(initiator_party, &names, &action.target),
+                            format!("{:?}", attack).yellow(),
+                            attack.damage
+                        );
+                    }
+                };
 
-        let target = event.state.targeted_member(&event.action.target);
-        if target.is_dead() {
-            println!(
-                "   ⇒ {} has {}",
-                color_participant(initiator_party, &names, &event.action.target,),
-                "given up on being alive".red()
-            );
-        } else {
-            println!(
-                "   ⇒ {} now has {} health",
-                color_participant(initiator_party, &names, &event.action.target,),
-                target.health
-            );
+                let target = event.state.targeted_member(&action.target);
+                if target.is_dead() {
+                    println!(
+                        "   ⇒ {} has {}",
+                        color_participant(initiator_party, &names, &action.target,),
+                        "given up on being alive".red()
+                    );
+                } else {
+                    println!(
+                        "   ⇒ {} now has {} health",
+                        color_participant(initiator_party, &names, &action.target,),
+                        target.health
+                    );
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
             weapon: Weapon::Fists(Fists { damage: 10.0 }),
             can_act: true,
         }],
+        can_retreat: true,
         retreated: false,
     };
 
@@ -52,6 +53,7 @@ fn main() {
                 can_act: true,
             },
         ],
+        can_retreat: true,
         retreated: false,
     };
 
@@ -82,6 +84,18 @@ fn main() {
             "{} {} with a score of {}.",
             "TL;DR:".bright_white(),
             "The initiating party is defeated".red(),
+            score
+        ),
+        OutcomeType::Remain(score) => println!(
+            "{} {} with a score of {}.",
+            "TL;DR:".bright_white(),
+            "The initiating party let the opponent flee".red(),
+            score
+        ),
+        OutcomeType::Retreat(score) => println!(
+            "{} {} with a score of {}.",
+            "TL;DR:".bright_white(),
+            "The initiating party retreated".red(),
             score
         ),
         OutcomeType::Unknown(score) => println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,9 @@ fn main() {
             health: 20.0,
             damage_taken: 0.0,
             weapon: Weapon::Fists(Fists { damage: 10.0 }),
+            can_act: true,
         }],
+        retreated: false,
     };
 
     let rng = RNG::try_from(&Language::Fantasy).unwrap();
@@ -40,14 +42,17 @@ fn main() {
                 health: 15.0,
                 damage_taken: 0.0,
                 weapon: Weapon::Stick(Stick { damage: 5.0 }),
+                can_act: true,
             },
             PartyMember {
                 id: 1,
                 health: 10.0,
                 damage_taken: 0.0,
                 weapon: Weapon::Fists(Fists { damage: 20.0 }),
+                can_act: true,
             },
         ],
+        retreated: false,
     };
 
     let rng = RNG::try_from(&Language::Demonic).unwrap();

--- a/src/party.rs
+++ b/src/party.rs
@@ -8,6 +8,8 @@ pub struct Party {
     pub id: usize,
     /// All members of the party.
     pub members: Vec<PartyMember>,
+    /// Indicates if the party has retreated from the encounter.
+    pub retreated: bool,
 }
 
 /// A participant.
@@ -20,6 +22,14 @@ pub struct Participant {
 }
 
 impl Party {
+    /// Makes every member unable to act in the encounter.
+    pub fn retreat(&mut self) {
+        self.retreated = true;
+        for member in self.members.iter_mut() {
+            member.can_act = false;
+        }
+    }
+
     /// Returns `true` if the party is defeated.
     ///
     /// ## Defeat
@@ -27,6 +37,16 @@ impl Party {
     /// are deceased or have fled the conflict.
     pub fn is_defeated(&self) -> bool {
         self.members.iter().all(PartyMember::is_dead)
+    }
+
+    /// Returns `true` if the party has retreated from the encounter.
+    pub fn has_retreated(&self) -> bool {
+        self.retreated
+    }
+
+    /// Returns `true` if at least one party can still act.
+    pub fn can_act(&self) -> bool {
+        self.members.iter().any(PartyMember::can_act)
     }
 
     /// Replaces the member identified by the party member's ID with the

--- a/src/party.rs
+++ b/src/party.rs
@@ -8,6 +8,8 @@ pub struct Party {
     pub id: usize,
     /// All members of the party.
     pub members: Vec<PartyMember>,
+    /// Indicates whether the party is allowed to retreat.
+    pub can_retreat: bool,
     /// Indicates if the party has retreated from the encounter.
     pub retreated: bool,
 }
@@ -24,6 +26,7 @@ pub struct Participant {
 impl Party {
     /// Makes every member unable to act in the encounter.
     pub fn retreat(&mut self) {
+        debug_assert!(self.can_retreat);
         self.retreated = true;
         for member in self.members.iter_mut() {
             member.can_act = false;
@@ -37,6 +40,11 @@ impl Party {
     /// are deceased or have fled the conflict.
     pub fn is_defeated(&self) -> bool {
         self.members.iter().all(PartyMember::is_dead)
+    }
+
+    /// Returns `true` if the party is able to retreat.
+    pub fn can_retreat(&self) -> bool {
+        self.can_retreat
     }
 
     /// Returns `true` if the party has retreated from the encounter.

--- a/src/party_member.rs
+++ b/src/party_member.rs
@@ -133,6 +133,7 @@ mod tests {
             health: 100.0,
             damage_taken: 0.0,
             weapon: Weapon::Stick(Stick { damage: 0.0 }),
+            can_act: true,
         };
 
         // Apply more damage than the subject has health.
@@ -157,6 +158,7 @@ mod tests {
             health: 100.0,
             damage_taken: 0.0,
             weapon: Weapon::Stick(Stick { damage: 0.0 }),
+            can_act: true,
         };
 
         let mut iter = member.clone().actions();

--- a/src/party_member.rs
+++ b/src/party_member.rs
@@ -12,6 +12,10 @@ pub struct PartyMember {
     pub damage_taken: f32,
     /// The weapon of choice.
     pub weapon: Weapon,
+    /// Whether the party member can currently act.
+    /// A member may not be able to act e.g. if they are paralyzed
+    /// or fled from the encounter.
+    pub can_act: bool,
 }
 
 impl PartyMember {
@@ -61,9 +65,9 @@ impl PartyMember {
         AttackIterator::new(self)
     }
 
-    /// Determines whether the current member can act..
+    /// Determines whether the current member can act.
     pub fn can_act(&self) -> bool {
-        !self.is_dead()
+        self.can_act && !self.is_dead()
     }
 
     /// Determines whether the action is applicable to this member.

--- a/src/value.rs
+++ b/src/value.rs
@@ -19,6 +19,10 @@ pub enum TerminalState {
     Win(f32),
     /// The maximizing player loses.
     Defeat(f32),
+    /// The player remained after the other player retreated.
+    Remain(f32),
+    /// The player retreated.
+    Retreat(f32),
     /// No clear decision can be made.
     Heuristic(f32),
     /// The branch is unexplored and has a default value.
@@ -126,6 +130,8 @@ impl TerminalState {
         match self {
             TerminalState::Win(value) => *value,
             TerminalState::Defeat(value) => *value,
+            TerminalState::Remain(value) => *value,
+            TerminalState::Retreat(value) => *value,
             TerminalState::Heuristic(value) => *value,
             TerminalState::OpenUnexplored(value) => *value,
         }
@@ -143,6 +149,8 @@ impl Deref for TerminalState {
         match self {
             TerminalState::Win(value) => value,
             TerminalState::Defeat(value) => value,
+            TerminalState::Remain(value) => value,
+            TerminalState::Retreat(value) => value,
             TerminalState::Heuristic(value) => value,
             TerminalState::OpenUnexplored(value) => value,
         }
@@ -154,6 +162,8 @@ impl Display for TerminalState {
         match self {
             TerminalState::Win(value) => write!(f, "win({})", value),
             TerminalState::Defeat(value) => write!(f, "defeat({})", value),
+            TerminalState::Remain(value) => write!(f, "remain({})", value),
+            TerminalState::Retreat(value) => write!(f, "retreat({})", value),
             TerminalState::Heuristic(value) => write!(f, "H({})", value),
             TerminalState::OpenUnexplored(value) => write!(f, "O({})", value),
         }


### PR DESCRIPTION
This changes the game such that either party is allowed to retreat from an encounter. A retreat results in a higher score than a defeat, but less than a win. Likewise, a remain (i.e., letting the other party flee without defeating them) is scored less than a win.